### PR TITLE
Replace Set by List to fix test failure

### DIFF
--- a/src/main/java/com/acme/axonsample/axonsample/Schedule.java
+++ b/src/main/java/com/acme/axonsample/axonsample/Schedule.java
@@ -5,7 +5,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/com/acme/axonsample/axonsample/WorkDay.java
+++ b/src/main/java/com/acme/axonsample/axonsample/WorkDay.java
@@ -4,10 +4,8 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import lombok.Data;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.eventsourcing.EventSourcingHandler;
@@ -22,7 +20,7 @@ public class WorkDay {
 
   @AggregateIdentifier private WorkDayId id;
   private LocalDate day;
-  @AggregateMember private Set<Schedule> schedules;
+  @AggregateMember private List<Schedule> schedules;
   private List<WorkLog> workLogs;
 
   public WorkDay() {}
@@ -101,7 +99,7 @@ public class WorkDay {
     }
 
     if (null == this.schedules) {
-      this.schedules = new HashSet<>();
+      this.schedules = new ArrayList<>();
     }
 
     if (!this.getSchedules().contains(schedule)) {


### PR DESCRIPTION
This `PR` aims to fix a test when using Set to hold a bag of schedules. For some reason the hash table differs  when using `HashSet` ending up in a test failure.

The test went fine when using `ArrayList`, I didn't check if the same going on in runtime or is just related to Axon fixture.